### PR TITLE
fix: compatibility with yarn 1.22.4

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -9,7 +9,7 @@ class Workspace {
 
     get workspaceSnapshot() {
         return runCommand('yarn',
-            ['workspaces', 'info', '--silent'],
+            ['--silent', 'workspaces', 'info'],
             { cwd: this.root }
         )
         .then(data => JSON.parse(data))


### PR DESCRIPTION
yarn 1.22.4 ignores `--silent` flag passed after `info` subcommand.

    SyntaxError: Unexpected token y in JSON at position 0
        at JSON.parse (<anonymous>)
        at /home/jirutjak/Projects/jirutka/ipynb2html/node_modules/yarn-version-bump/src/workspace.js:15:28